### PR TITLE
docs: hide BCD entry menu

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
     page-editable: true
     page-next-release: false
     page-hide-search-bar: true
+    page-hide-components: 'bcd'
 nav:
   - modules/ROOT/taxonomy.adoc
   - modules/cli/taxonomy.adoc


### PR DESCRIPTION
As for recent Bonita versions and test-toolkit, we don't want to highlight BCD (which is deprecated) in the top menu.